### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2024-10-21
+
+### 📇 Features
+
+- *(bridge)* Enhance puente days display with past/future color distinction - ([8783309](https://github.com/k3ii/revq/commit/8783309b0b84a6417275f4feba95065c7f9c6c54))
+- *(bridge)* Correct logic to filter out bridge days - ([11b9c0f](https://github.com/k3ii/revq/commit/11b9c0f5f38e2c8699f0f1de57c0bec29c891c91))
+- *(bridge)* Order holiday chronologically - ([6608fd3](https://github.com/k3ii/revq/commit/6608fd38c7690446837513d5dad9c462e82c4a7f))
+- *(bridge)* Remove deduplicate holidays - ([c5ab479](https://github.com/k3ii/revq/commit/c5ab479572c4ef17ce70f06d6a991815bf51e12b))
+- *(bridge)* Extend puente logic to cover additional bridge days - ([57993d2](https://github.com/k3ii/revq/commit/57993d2aeab52f09229d2b01ead512b9d60f24f9))
+- *(bridge)* Add subcommand aliases - ([4500269](https://github.com/k3ii/revq/commit/4500269d6a8de0a8c89c746e5d6182e5f6f078eb))
+- *(cal)* Add other countries dataset - ([dc785e4](https://github.com/k3ii/revq/commit/dc785e450d5d902b035c16c7c535f7a2b25a1c61))
+- *(cal)* Print table of holidays - ([3231e1f](https://github.com/k3ii/revq/commit/3231e1fa4ce377c0d41e134a71808d30757a971b))
+- *(cli)* Add version - ([aa4bd75](https://github.com/k3ii/revq/commit/aa4bd75f2bbe078aa255e3a51746cad3a45b77df))
+- *(cli)* Add arguments to subcommand calendar - ([0ce4edf](https://github.com/k3ii/revq/commit/0ce4edf7dd2184d022da0306cca3c97682f2eee6))
+- *(cli)* Add arguments to subcommand bridge - ([07b6898](https://github.com/k3ii/revq/commit/07b689853aee6e9f5b39505c4bfdc4fdea15c240))
+- Add calendar - ([cd4dc5d](https://github.com/k3ii/revq/commit/cd4dc5d5f7d5de1301747a703ff214760c594af0))
+- Add cli - ([30ea1f8](https://github.com/k3ii/revq/commit/30ea1f85cc532d375519b176d807df2a4d4e285a))
+- Add parser - ([4e57cdb](https://github.com/k3ii/revq/commit/4e57cdb88ba443fe486ded9f4b7b0875ce2d436a))
+- Add main.rs - ([9084fcd](https://github.com/k3ii/revq/commit/9084fcd21731870e9a8a9c1a0f569b8fa82870dd))
+
+### 🐛 Bug Fixes
+
+- *(bridge)* Format output total holidays for month and year - ([5769da3](https://github.com/k3ii/revq/commit/5769da3525c3a6d68f7596e854f1cc9bb5b23e57))
+- *(cli)* Add country code list to help of config --default-country - ([7f022f2](https://github.com/k3ii/revq/commit/7f022f24780df5823f1857dd182b2c34f23f6fc1))
+- Return error when month is incorrectly input - ([9d6e9f8](https://github.com/k3ii/revq/commit/9d6e9f8d7de16df7e2d380be1f0cadcf9cb4ed88))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(cargo)* Add openssl featured vendored - ([62d3f34](https://github.com/k3ii/revq/commit/62d3f34e94e660702abaeeb418f4d8757bacd9e2))
+- *(cargo)* Add prettytable - ([3d375c8](https://github.com/k3ii/revq/commit/3d375c8038edfbfaac19c5b79dd015d0b0a173d7))
+- *(cargo)* Add Dependencies - ([97e9f7d](https://github.com/k3ii/revq/commit/97e9f7de8a6f62252607dd305ec955f43902e8f7))
+- *(gh)* Add fundings.yml - ([a03773b](https://github.com/k3ii/revq/commit/a03773b44f845a073717101a18cfd8ccfdaa4c68))
+- Add release-plz - ([22b6fb5](https://github.com/k3ii/revq/commit/22b6fb571fef090cdd8c12ea20323eb7c0094bad))
+- Add cliff.toml - ([fdc6a7f](https://github.com/k3ii/revq/commit/fdc6a7f9ae5e0d38edb5f36a1a60ab5b5e6f6a14))
+- Add License - ([ce38fb5](https://github.com/k3ii/revq/commit/ce38fb5851197b03a2157367ae3130c29d368688))
+- Add cargo metadata - ([35eec3a](https://github.com/k3ii/revq/commit/35eec3a3ba2b2fee96d66c1ddb6a80df5e48c0d7))
+- Add GH workflows - ([cada1f4](https://github.com/k3ii/revq/commit/cada1f4e0d5b5406c52cd2d9904ad1f2e6725d8c))
+- Update README - ([175d205](https://github.com/k3ii/revq/commit/175d2053a2b81a00f30a6d6b2f87ac20f35d11db))
+- Add assets - ([ec5c2b6](https://github.com/k3ii/revq/commit/ec5c2b64320a87a49cb950ad5417f065b298de3f))
+- Add .gitignore - ([8091f3a](https://github.com/k3ii/revq/commit/8091f3ad67925fd42f7a195053500151776a6f16))
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "atomic-waker"
@@ -155,9 +155,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.23"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -460,36 +460,36 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -593,15 +593,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -714,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -743,9 +743,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -758,9 +758,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libredox"
@@ -856,21 +856,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
@@ -980,12 +977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1107,9 +1098,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64",
  "bytes",
@@ -1184,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1206,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -1223,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -1235,9 +1226,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -1293,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -1424,9 +1415,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1652,9 +1643,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -1673,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"
@@ -1723,9 +1714,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1734,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -1749,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1761,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1771,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1784,15 +1775,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
## 🤖 New release
* `conze`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0] - 2024-10-21

### 📇 Features

- *(bridge)* Enhance puente days display with past/future color distinction - ([8783309](https://github.com/k3ii/revq/commit/8783309b0b84a6417275f4feba95065c7f9c6c54))
- *(bridge)* Correct logic to filter out bridge days - ([11b9c0f](https://github.com/k3ii/revq/commit/11b9c0f5f38e2c8699f0f1de57c0bec29c891c91))
- *(bridge)* Order holiday chronologically - ([6608fd3](https://github.com/k3ii/revq/commit/6608fd38c7690446837513d5dad9c462e82c4a7f))
- *(bridge)* Remove deduplicate holidays - ([c5ab479](https://github.com/k3ii/revq/commit/c5ab479572c4ef17ce70f06d6a991815bf51e12b))
- *(bridge)* Extend puente logic to cover additional bridge days - ([57993d2](https://github.com/k3ii/revq/commit/57993d2aeab52f09229d2b01ead512b9d60f24f9))
- *(bridge)* Add subcommand aliases - ([4500269](https://github.com/k3ii/revq/commit/4500269d6a8de0a8c89c746e5d6182e5f6f078eb))
- *(cal)* Add other countries dataset - ([dc785e4](https://github.com/k3ii/revq/commit/dc785e450d5d902b035c16c7c535f7a2b25a1c61))
- *(cal)* Print table of holidays - ([3231e1f](https://github.com/k3ii/revq/commit/3231e1fa4ce377c0d41e134a71808d30757a971b))
- *(cli)* Add version - ([aa4bd75](https://github.com/k3ii/revq/commit/aa4bd75f2bbe078aa255e3a51746cad3a45b77df))
- *(cli)* Add arguments to subcommand calendar - ([0ce4edf](https://github.com/k3ii/revq/commit/0ce4edf7dd2184d022da0306cca3c97682f2eee6))
- *(cli)* Add arguments to subcommand bridge - ([07b6898](https://github.com/k3ii/revq/commit/07b689853aee6e9f5b39505c4bfdc4fdea15c240))
- Add calendar - ([cd4dc5d](https://github.com/k3ii/revq/commit/cd4dc5d5f7d5de1301747a703ff214760c594af0))
- Add cli - ([30ea1f8](https://github.com/k3ii/revq/commit/30ea1f85cc532d375519b176d807df2a4d4e285a))
- Add parser - ([4e57cdb](https://github.com/k3ii/revq/commit/4e57cdb88ba443fe486ded9f4b7b0875ce2d436a))
- Add main.rs - ([9084fcd](https://github.com/k3ii/revq/commit/9084fcd21731870e9a8a9c1a0f569b8fa82870dd))

### 🐛 Bug Fixes

- *(bridge)* Format output total holidays for month and year - ([5769da3](https://github.com/k3ii/revq/commit/5769da3525c3a6d68f7596e854f1cc9bb5b23e57))
- *(cli)* Add country code list to help of config --default-country - ([7f022f2](https://github.com/k3ii/revq/commit/7f022f24780df5823f1857dd182b2c34f23f6fc1))
- Return error when month is incorrectly input - ([9d6e9f8](https://github.com/k3ii/revq/commit/9d6e9f8d7de16df7e2d380be1f0cadcf9cb4ed88))

### ⚙️ Miscellaneous Tasks

- *(cargo)* Add openssl featured vendored - ([62d3f34](https://github.com/k3ii/revq/commit/62d3f34e94e660702abaeeb418f4d8757bacd9e2))
- *(cargo)* Add prettytable - ([3d375c8](https://github.com/k3ii/revq/commit/3d375c8038edfbfaac19c5b79dd015d0b0a173d7))
- *(cargo)* Add Dependencies - ([97e9f7d](https://github.com/k3ii/revq/commit/97e9f7de8a6f62252607dd305ec955f43902e8f7))
- *(gh)* Add fundings.yml - ([a03773b](https://github.com/k3ii/revq/commit/a03773b44f845a073717101a18cfd8ccfdaa4c68))
- Add release-plz - ([22b6fb5](https://github.com/k3ii/revq/commit/22b6fb571fef090cdd8c12ea20323eb7c0094bad))
- Add cliff.toml - ([fdc6a7f](https://github.com/k3ii/revq/commit/fdc6a7f9ae5e0d38edb5f36a1a60ab5b5e6f6a14))
- Add License - ([ce38fb5](https://github.com/k3ii/revq/commit/ce38fb5851197b03a2157367ae3130c29d368688))
- Add cargo metadata - ([35eec3a](https://github.com/k3ii/revq/commit/35eec3a3ba2b2fee96d66c1ddb6a80df5e48c0d7))
- Add GH workflows - ([cada1f4](https://github.com/k3ii/revq/commit/cada1f4e0d5b5406c52cd2d9904ad1f2e6725d8c))
- Update README - ([175d205](https://github.com/k3ii/revq/commit/175d2053a2b81a00f30a6d6b2f87ac20f35d11db))
- Add assets - ([ec5c2b6](https://github.com/k3ii/revq/commit/ec5c2b64320a87a49cb950ad5417f065b298de3f))
- Add .gitignore - ([8091f3a](https://github.com/k3ii/revq/commit/8091f3ad67925fd42f7a195053500151776a6f16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).