### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,44 @@ All notable changes to this project will be documented in this file.
 - Add assets - ([ec5c2b6](https://github.com/k3ii/revq/commit/ec5c2b64320a87a49cb950ad5417f065b298de3f))
 - Add .gitignore - ([8091f3a](https://github.com/k3ii/revq/commit/8091f3ad67925fd42f7a195053500151776a6f16))
 
+## [0.1.0] - 2024-10-21
+
+### 📇 Features
+
+- *(bridge)* Enhance puente days display with past/future color distinction - ([8783309](https://github.com/k3ii/revq/commit/8783309b0b84a6417275f4feba95065c7f9c6c54))
+- *(bridge)* Correct logic to filter out bridge days - ([11b9c0f](https://github.com/k3ii/revq/commit/11b9c0f5f38e2c8699f0f1de57c0bec29c891c91))
+- *(bridge)* Order holiday chronologically - ([6608fd3](https://github.com/k3ii/revq/commit/6608fd38c7690446837513d5dad9c462e82c4a7f))
+- *(bridge)* Remove deduplicate holidays - ([c5ab479](https://github.com/k3ii/revq/commit/c5ab479572c4ef17ce70f06d6a991815bf51e12b))
+- *(bridge)* Extend puente logic to cover additional bridge days - ([57993d2](https://github.com/k3ii/revq/commit/57993d2aeab52f09229d2b01ead512b9d60f24f9))
+- *(bridge)* Add subcommand aliases - ([4500269](https://github.com/k3ii/revq/commit/4500269d6a8de0a8c89c746e5d6182e5f6f078eb))
+- *(cal)* Add other countries dataset - ([dc785e4](https://github.com/k3ii/revq/commit/dc785e450d5d902b035c16c7c535f7a2b25a1c61))
+- *(cal)* Print table of holidays - ([3231e1f](https://github.com/k3ii/revq/commit/3231e1fa4ce377c0d41e134a71808d30757a971b))
+- *(cli)* Add version - ([aa4bd75](https://github.com/k3ii/revq/commit/aa4bd75f2bbe078aa255e3a51746cad3a45b77df))
+- *(cli)* Add arguments to subcommand calendar - ([0ce4edf](https://github.com/k3ii/revq/commit/0ce4edf7dd2184d022da0306cca3c97682f2eee6))
+- *(cli)* Add arguments to subcommand bridge - ([07b6898](https://github.com/k3ii/revq/commit/07b689853aee6e9f5b39505c4bfdc4fdea15c240))
+- Add calendar - ([cd4dc5d](https://github.com/k3ii/revq/commit/cd4dc5d5f7d5de1301747a703ff214760c594af0))
+- Add cli - ([30ea1f8](https://github.com/k3ii/revq/commit/30ea1f85cc532d375519b176d807df2a4d4e285a))
+- Add parser - ([4e57cdb](https://github.com/k3ii/revq/commit/4e57cdb88ba443fe486ded9f4b7b0875ce2d436a))
+- Add main.rs - ([9084fcd](https://github.com/k3ii/revq/commit/9084fcd21731870e9a8a9c1a0f569b8fa82870dd))
+
+### 🐛 Bug Fixes
+
+- *(bridge)* Format output total holidays for month and year - ([5769da3](https://github.com/k3ii/revq/commit/5769da3525c3a6d68f7596e854f1cc9bb5b23e57))
+- *(cli)* Add country code list to help of config --default-country - ([7f022f2](https://github.com/k3ii/revq/commit/7f022f24780df5823f1857dd182b2c34f23f6fc1))
+- Return error when month is incorrectly input - ([9d6e9f8](https://github.com/k3ii/revq/commit/9d6e9f8d7de16df7e2d380be1f0cadcf9cb4ed88))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(cargo)* Add openssl featured vendored - ([62d3f34](https://github.com/k3ii/revq/commit/62d3f34e94e660702abaeeb418f4d8757bacd9e2))
+- *(cargo)* Add prettytable - ([3d375c8](https://github.com/k3ii/revq/commit/3d375c8038edfbfaac19c5b79dd015d0b0a173d7))
+- *(cargo)* Add Dependencies - ([97e9f7d](https://github.com/k3ii/revq/commit/97e9f7de8a6f62252607dd305ec955f43902e8f7))
+- *(gh)* Add fundings.yml - ([a03773b](https://github.com/k3ii/revq/commit/a03773b44f845a073717101a18cfd8ccfdaa4c68))
+- Add release-plz - ([22b6fb5](https://github.com/k3ii/revq/commit/22b6fb571fef090cdd8c12ea20323eb7c0094bad))
+- Add cliff.toml - ([fdc6a7f](https://github.com/k3ii/revq/commit/fdc6a7f9ae5e0d38edb5f36a1a60ab5b5e6f6a14))
+- Add License - ([ce38fb5](https://github.com/k3ii/revq/commit/ce38fb5851197b03a2157367ae3130c29d368688))
+- Add cargo metadata - ([35eec3a](https://github.com/k3ii/revq/commit/35eec3a3ba2b2fee96d66c1ddb6a80df5e48c0d7))
+- Add GH workflows - ([cada1f4](https://github.com/k3ii/revq/commit/cada1f4e0d5b5406c52cd2d9904ad1f2e6725d8c))
+- Update README - ([175d205](https://github.com/k3ii/revq/commit/175d2053a2b81a00f30a6d6b2f87ac20f35d11db))
+- Add assets - ([ec5c2b6](https://github.com/k3ii/revq/commit/ec5c2b64320a87a49cb950ad5417f065b298de3f))
+- Add .gitignore - ([8091f3a](https://github.com/k3ii/revq/commit/8091f3ad67925fd42f7a195053500151776a6f16))
+


### PR DESCRIPTION
## 🤖 New release
* `conze`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).